### PR TITLE
improments

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ All commands can be accessed via the Command Palette (Ctrl+Shift+P or Cmd+Shift+
 *   **Custom Search: Delete Filter**:
     *   Shows a list of your saved filters.
     *   Select a filter to permanently remove it.
-*   **Custom Search: Combine Filters**:
-    *   Allows selecting multiple existing filters.
-    *   Prompts for a new name and combines the include/exclude patterns (comma-separated) of the selected filters into a new filter.
 *   **Custom Search: Edit Filter**:
     *   Shows a list of your saved filters.
     *   Selecting a filter allows you to modify its name, include pattern, and exclude pattern via input boxes.
@@ -37,5 +34,26 @@ All commands can be accessed via the Command Palette (Ctrl+Shift+P or Cmd+Shift+
     *   Right-click one or more files (with extensions) in the File Explorer.
     *   Choose this option to select an existing filter (or create a new one).
     *   You'll be prompted to either append the selected file type(s) to the filter's exclude pattern or overwrite the existing pattern. Duplicates are skipped when appending.
+
+## Filter Scope and Storage
+
+Filters can be saved with two different scopes:
+
+### Global Filters
+*   **Scope**: Available across all projects and workspaces
+*   **Storage Location**: Stored in VS Code user settings
+    *   Filter definitions: `custom-search-filters.globalFilters`
+    *   Enable/disable states: `custom-search-filters.globalFiltersEnabled`
+*   **Sync**: Can be synced across devices using VS Code Settings Sync
+*   **Enable/Disable**: You can enable or disable global filters in VS Code settings. Disabled filters will not appear in the filter selection list
+*   **Default State**: All global filters are enabled by default
+
+### Workspace Filters
+*   **Scope**: Only available in the current workspace/project
+*   **Storage Location**: Stored in `.vscode/custom-search-filters.json` in the project root directory
+*   **Sync**: Included in the project repository (if committed), making them available to all team members
+*   **Visibility**: Always visible in the filter selection list (cannot be disabled)
+
+When creating a new filter, you'll be prompted to choose between Global or Workspace scope. The filter list displays both types with icons indicating their scope (🌐 for Global, 📁 for Workspace).
 
 **Enjoy!**

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/EWYan/custom-search-filters.git"
   },
-  "version": "0.1.3",
+  "version": "0.1.4",
   "engines": {
     "vscode": "^1.96.2"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "onCommand:custom-search-filters.addFilter",
     "onCommand:custom-search-filters.selectAndSearch",
     "onCommand:custom-search-filters.deleteFilter",
-    "onCommand:custom-search-filters.combineFilters",
     "onCommand:custom-search-filters.addFolderToInclude",
     "onCommand:custom-search-filters.addFolderToExclude",
     "onCommand:custom-search-filters.editFilter",
@@ -41,10 +40,6 @@
         "title": "Custom Search: Delete Filter"
       },
       {
-        "command": "custom-search-filters.combineFilters",
-        "title": "Custom Search: Combine Filters"
-      },
-      {
         "command": "custom-search-filters.addFolderToInclude",
         "title": "Custom Search: Add Folder to Include Filter"
       },
@@ -65,6 +60,46 @@
         "title": "Custom Search: Add File Type to Exclude Filter"
       }
     ],
+    "configuration": {
+      "title": "Custom Search Filters",
+      "properties": {
+        "custom-search-filters.globalFilters": {
+          "type": "array",
+          "default": [],
+          "description": "Global search filters that are available across all projects. These filters can be synced via VS Code Settings Sync.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Filter name"
+              },
+              "include": {
+                "type": "string",
+                "description": "Glob pattern for files to include"
+              },
+              "exclude": {
+                "type": "string",
+                "description": "Glob pattern for files to exclude"
+              },
+              "scope": {
+                "type": "string",
+                "enum": ["global"],
+                "description": "Filter scope (should be 'global' for settings)"
+              }
+            }
+          }
+        },
+        "custom-search-filters.globalFiltersEnabled": {
+          "type": "object",
+          "default": {},
+          "description": "Enable/disable global filters. Each filter name maps to a boolean value indicating if it's enabled. All global filters are automatically added here when created, and removed when deleted. Filters are enabled (true) by default.",
+          "additionalProperties": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
     "menus": {
       "editor/title": [
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,44 +3,204 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 import * as path from 'path'; // Need path module for normalization
+import * as fs from 'fs'; // Need fs module for file operations
 
 // Define the structure for a search filter
 interface SearchFilter {
 	name: string;
 	include: string; // Glob pattern for files to include
 	exclude: string; // Glob pattern for files to exclude
+	scope?: 'global' | 'workspace'; // Scope of the filter: global or workspace-specific
 }
 
 // Key for storing filters in global state
 const FILTERS_STORAGE_KEY = 'customSearchFilters';
+const PROJECT_FILTERS_FILE = '.vscode/custom-search-filters.json';
 
-// Helper function to save filters and handle overwrites
-async function saveFilter(context: vscode.ExtensionContext, newFilter: SearchFilter): Promise<boolean> {
-	let existingFilters: SearchFilter[] = context.globalState.get<SearchFilter[]>(FILTERS_STORAGE_KEY) || [];
-	const existingIndex = existingFilters.findIndex(f => f.name === newFilter.name);
+// Helper function to get workspace root folder
+function getWorkspaceFolder(): vscode.WorkspaceFolder | undefined {
+	const workspaceFolders = vscode.workspace.workspaceFolders;
+	return workspaceFolders && workspaceFolders.length > 0 ? workspaceFolders[0] : undefined;
+}
 
-	if (existingIndex > -1) {
-		const overwrite = await vscode.window.showQuickPick(['Yes', 'No'], {
-			placeHolder: `Filter '${newFilter.name}' already exists. Overwrite?`
-		});
-		if (overwrite === 'Yes') {
-			existingFilters[existingIndex] = newFilter;
-		} else {
-			vscode.window.showInformationMessage('Filter not saved.');
-			return false; // Indicate not saved
-		}
-	} else {
-		existingFilters.push(newFilter);
+// Helper function to get project filters file path
+function getProjectFiltersPath(): string | undefined {
+	const workspaceFolder = getWorkspaceFolder();
+	if (!workspaceFolder) {
+		return undefined;
+	}
+	return path.join(workspaceFolder.uri.fsPath, PROJECT_FILTERS_FILE);
+}
+
+// Helper function to load project-scoped filters
+function loadProjectFilters(): SearchFilter[] {
+	const filtersPath = getProjectFiltersPath();
+	if (!filtersPath) {
+		return [];
 	}
 
 	try {
-		await context.globalState.update(FILTERS_STORAGE_KEY, existingFilters);
-		vscode.window.showInformationMessage(`Filter '${newFilter.name}' saved successfully!`);
-		return true; // Indicate saved
+		if (fs.existsSync(filtersPath)) {
+			const fileContent = fs.readFileSync(filtersPath, 'utf8');
+			const filters: SearchFilter[] = JSON.parse(fileContent);
+			// Ensure all project filters have scope set
+			return filters.map(f => ({ ...f, scope: 'workspace' }));
+		}
+	} catch (error) {
+		console.error('Error loading project filters:', error);
+	}
+	return [];
+}
+
+// Helper function to save project-scoped filters
+function saveProjectFilters(filters: SearchFilter[]): boolean {
+	const filtersPath = getProjectFiltersPath();
+	if (!filtersPath) {
+		return false;
+	}
+
+	try {
+		const filtersDir = path.dirname(filtersPath);
+		// Create .vscode directory if it doesn't exist
+		if (!fs.existsSync(filtersDir)) {
+			fs.mkdirSync(filtersDir, { recursive: true });
+		}
+		// Only save workspace-scoped filters
+		const workspaceFilters = filters.filter(f => f.scope === 'workspace');
+		fs.writeFileSync(filtersPath, JSON.stringify(workspaceFilters, null, 2), 'utf8');
+		return true;
+	} catch (error) {
+		console.error('Error saving project filters:', error);
+		return false;
+	}
+}
+
+// Helper function to load all filters (global + project)
+function loadAllFilters(context: vscode.ExtensionContext): SearchFilter[] {
+	const globalFilters: SearchFilter[] = context.globalState.get<SearchFilter[]>(FILTERS_STORAGE_KEY) || [];
+	// Ensure all global filters have scope set
+	const globalFiltersWithScope = globalFilters.map(f => ({ ...f, scope: f.scope || 'global' }));
+	const projectFilters = loadProjectFilters();
+	return [...globalFiltersWithScope, ...projectFilters];
+}
+
+// Helper function to format filter label with scope indicator
+function formatFilterLabel(filter: SearchFilter): string {
+	const scopeIcon = filter.scope === 'workspace' ? '$(folder)' : '$(globe)';
+	const scopeText = filter.scope === 'workspace' ? 'Project' : 'Global';
+	return `${scopeIcon} ${filter.name} (${scopeText})`;
+}
+
+// Helper function to delete a filter
+async function deleteFilter(context: vscode.ExtensionContext, filterToDelete: SearchFilter): Promise<boolean> {
+	try {
+		const filterScope = filterToDelete.scope || 'global';
+		
+		if (filterScope === 'workspace') {
+			// Delete from project file
+			const projectFilters = loadProjectFilters();
+			const updatedFilters = projectFilters.filter(f => !(f.name === filterToDelete.name && f.scope === 'workspace'));
+			if (saveProjectFilters(updatedFilters)) {
+				vscode.window.showInformationMessage(`Search filter '${filterToDelete.name}' deleted from project successfully!`);
+				return true;
+			} else {
+				vscode.window.showErrorMessage('Failed to delete filter from project. See console for details.');
+				return false;
+			}
+		} else {
+			// Delete from global state
+			let globalFilters: SearchFilter[] = context.globalState.get<SearchFilter[]>(FILTERS_STORAGE_KEY) || [];
+			const updatedFilters = globalFilters.filter(f => f.name !== filterToDelete.name);
+			await context.globalState.update(FILTERS_STORAGE_KEY, updatedFilters);
+			vscode.window.showInformationMessage(`Search filter '${filterToDelete.name}' deleted from global successfully!`);
+			return true;
+		}
+	} catch (error) {
+		console.error('Error deleting search filter:', error);
+		vscode.window.showErrorMessage('Failed to delete search filter. See console for details.');
+		return false;
+	}
+}
+
+// Helper function to ask user about filter scope
+async function askFilterScope(): Promise<'global' | 'workspace' | undefined> {
+	const scope = await vscode.window.showQuickPick<{ label: string; description: string; value: 'global' | 'workspace' }>(
+		[
+			{ label: '$(globe) Global', description: 'Available across all projects', value: 'global' },
+			{ label: '$(folder) Current Project', description: 'Only for this workspace', value: 'workspace' }
+		],
+		{
+			placeHolder: 'Where should this filter be saved?'
+		}
+	);
+	return scope?.value;
+}
+
+// Helper function to save filters and handle overwrites
+async function saveFilter(context: vscode.ExtensionContext, newFilter: SearchFilter, scope?: 'global' | 'workspace'): Promise<boolean> {
+	// Determine scope: use provided scope, or filter's scope, or ask user
+	let filterScope: 'global' | 'workspace' = scope || newFilter.scope || 'global';
+	
+	// If scope is not set and we're creating a new filter, ask the user
+	if (!newFilter.scope && !scope) {
+		const selectedScope = await askFilterScope();
+		if (!selectedScope) {
+			vscode.window.showInformationMessage('Filter not saved.');
+			return false;
+		}
+		filterScope = selectedScope;
+	}
+	
+	newFilter.scope = filterScope;
+
+	// Check for conflicts in the appropriate storage
+	const allFilters = loadAllFilters(context);
+	const existingFilter = allFilters.find(f => f.name === newFilter.name && f.scope === filterScope);
+
+	if (existingFilter) {
+		const overwrite = await vscode.window.showQuickPick(['Yes', 'No'], {
+			placeHolder: `Filter '${newFilter.name}' already exists in ${filterScope === 'global' ? 'global' : 'project'} scope. Overwrite?`
+		});
+		if (overwrite !== 'Yes') {
+			vscode.window.showInformationMessage('Filter not saved.');
+			return false;
+		}
+	}
+
+	try {
+		if (filterScope === 'workspace') {
+			// Save to project file
+			const projectFilters = loadProjectFilters();
+			const existingIndex = projectFilters.findIndex(f => f.name === newFilter.name);
+			if (existingIndex > -1) {
+				projectFilters[existingIndex] = newFilter;
+			} else {
+				projectFilters.push(newFilter);
+			}
+			if (saveProjectFilters(projectFilters)) {
+				vscode.window.showInformationMessage(`Filter '${newFilter.name}' saved to project successfully!`);
+				return true;
+			} else {
+				vscode.window.showErrorMessage('Failed to save filter to project. See console for details.');
+				return false;
+			}
+		} else {
+			// Save to global state
+			let globalFilters: SearchFilter[] = context.globalState.get<SearchFilter[]>(FILTERS_STORAGE_KEY) || [];
+			const existingIndex = globalFilters.findIndex(f => f.name === newFilter.name);
+			if (existingIndex > -1) {
+				globalFilters[existingIndex] = newFilter;
+			} else {
+				globalFilters.push(newFilter);
+			}
+			await context.globalState.update(FILTERS_STORAGE_KEY, globalFilters);
+			vscode.window.showInformationMessage(`Filter '${newFilter.name}' saved globally successfully!`);
+			return true;
+		}
 	} catch (error) {
 		console.error('Error saving search filter:', error);
 		vscode.window.showErrorMessage('Failed to save search filter. See console for details.');
-		return false; // Indicate error
+		return false;
 	}
 }
 
@@ -103,12 +263,12 @@ async function addFolderToFilter(targetUriOrUris: vscode.Uri | vscode.Uri[] | un
     const patternsToAddString = folderPatterns.join(', '); // For display purposes
 
 	// --- Filter Selection (remains similar) ---
-	const savedFilters: SearchFilter[] = context.globalState.get<SearchFilter[]>(FILTERS_STORAGE_KEY) || [];
+	const savedFilters: SearchFilter[] = loadAllFilters(context);
 	const createNewOption = { label: "$(add) Create New Filter...", description: `Create a new filter with ${folderPatterns.length} folder(s)`, name: null };
 	const quickPickItems = [
         createNewOption,
 		...savedFilters.map(filter => ({ 
-			label: filter.name, 
+			label: formatFilterLabel(filter), 
 			description: `Include: ${filter.include || '(none)'}, Exclude: ${filter.exclude || '(none)'}`, // Fixed typo
 			filter: filter // Store the actual filter object
 		}))
@@ -145,7 +305,7 @@ async function addFolderToFilter(targetUriOrUris: vscode.Uri | vscode.Uri[] | un
              });
 			newFilter.include = includePattern || '';
 		}
-		await saveFilter(context, newFilter);
+		await saveFilter(context, newFilter, undefined);
 
 	} else if ('filter' in selectedItem && selectedItem.filter) {
 		// Add to existing filter
@@ -191,7 +351,8 @@ async function addFolderToFilter(targetUriOrUris: vscode.Uri | vscode.Uri[] | un
 		} else {
             filterToUpdate.exclude = (addMethod.action === 'append') ? combinedPatternAppend : combinedPatternOverwrite;
 		}
-		await saveFilter(context, filterToUpdate);
+		// Preserve the existing scope when updating
+		await saveFilter(context, filterToUpdate, filterToUpdate.scope);
 	}
 }
 
@@ -231,12 +392,12 @@ async function addFileTypeToFilter(targetUriOrUris: vscode.Uri | vscode.Uri[] | 
     const patternsToAddString = fileTypePatterns.join(', '); // For display
 
 	// --- Filter Selection (remains similar) ---
-	const savedFilters: SearchFilter[] = context.globalState.get<SearchFilter[]>(FILTERS_STORAGE_KEY) || [];
+	const savedFilters: SearchFilter[] = loadAllFilters(context);
     const createNewOption = { label: "$(add) Create New Filter...", description: `Create a new filter with ${fileTypePatterns.length} file type(s)`, name: null };
 	const quickPickItems = [
         createNewOption,
 		...savedFilters.map(filter => ({ 
-			label: filter.name, 
+			label: formatFilterLabel(filter), 
 			description: `Include: ${filter.include || '(none)'}, Exclude: ${filter.exclude || '(none)'}`, // Fixed typo
 			filter: filter // Store the actual filter object
 		}))
@@ -273,7 +434,7 @@ async function addFileTypeToFilter(targetUriOrUris: vscode.Uri | vscode.Uri[] | 
              });
 			newFilter.include = includePattern || '';
 		}
-		await saveFilter(context, newFilter);
+		await saveFilter(context, newFilter, undefined);
 
 	} else if ('filter' in selectedItem && selectedItem.filter) {
         // Add to existing filter
@@ -317,7 +478,8 @@ async function addFileTypeToFilter(targetUriOrUris: vscode.Uri | vscode.Uri[] | 
 		} else {
             filterToUpdate.exclude = (addMethod.action === 'append') ? combinedPatternAppend : combinedPatternOverwrite;
 		}
-		await saveFilter(context, filterToUpdate);
+		// Preserve the existing scope when updating
+		await saveFilter(context, filterToUpdate, filterToUpdate.scope);
 	}
 }
 
@@ -371,39 +533,70 @@ export function activate(context: vscode.ExtensionContext) {
 	// Command to select a filter and trigger search
 	const selectAndSearchDisposable = vscode.commands.registerCommand('custom-search-filters.selectAndSearch', async () => {
 		// 1. Retrieve saved filters
-		const savedFilters: SearchFilter[] = context.globalState.get<SearchFilter[]>(FILTERS_STORAGE_KEY) || [];
+		let savedFilters: SearchFilter[] = loadAllFilters(context);
 
 		if (savedFilters.length === 0) {
 			vscode.window.showInformationMessage('No custom search filters saved yet. Use the "Add Custom Search Filter" command to create one.');
 			return;
 		}
 
-		// 2. Prepare Quick Pick items
-		const quickPickItems = savedFilters.map(filter => ({ 
-			label: filter.name, 
-			description: `Include: ${filter.include || '(none)'}, Exclude: ${filter.exclude || '(none)'}`, // Show patterns in description
-			filter: filter // Store the actual filter object
-		}));
+		// Create QuickPick instance to handle button clicks
+		const quickPick = vscode.window.createQuickPick();
+		quickPick.placeholder = 'Select a custom search filter to apply';
 
-		// 3. Show Quick Pick to select a filter
-		const selectedItem = await vscode.window.showQuickPick(quickPickItems, { 
-			placeHolder: 'Select a custom search filter to apply' 
+		// Function to update QuickPick items
+		const updateQuickPickItems = () => {
+			savedFilters = loadAllFilters(context);
+			quickPick.items = savedFilters.map(filter => ({
+				label: formatFilterLabel(filter),
+				description: `Include: ${filter.include || '(none)'}, Exclude: ${filter.exclude || '(none)'}`,
+				filter: filter,
+				buttons: [{
+					iconPath: new vscode.ThemeIcon('x'),
+					tooltip: 'Delete filter'
+				}]
+			}));
+		};
+
+		updateQuickPickItems();
+
+		// Handle button clicks (delete)
+		quickPick.onDidTriggerItemButton(async (e) => {
+			const filterToDelete = (e.item as any).filter;
+			if (filterToDelete) {
+				const confirmed = await vscode.window.showWarningMessage(
+					`Are you sure you want to delete filter '${filterToDelete.name}'?`,
+					{ modal: true },
+					'Delete',
+					'Cancel'
+				);
+				if (confirmed === 'Delete') {
+					await deleteFilter(context, filterToDelete);
+					updateQuickPickItems(); // Refresh the list
+				}
+			}
 		});
 
-		if (!selectedItem) { return; } // User cancelled
-
-		// 4. Execute the built-in search command with the selected filter's parameters
-		const selectedFilter = selectedItem.filter;
-		vscode.commands.executeCommand('workbench.action.findInFiles', {
-			// query: '', // Start with an empty query, user will type it
-			filesToInclude: selectedFilter.include,
-			filesToExclude: selectedFilter.exclude,
-			triggerSearch: true, // Optional: Immediately trigger search? Might be better false.
-            isCaseSensitive: false, // Default search settings
-            matchWholeWord: false, // Default search settings
-            isRegex: false, // Default search settings
-			showIncludesExcludes: true // Ensure the include/exclude boxes are visible
+		// Handle item selection (search)
+		quickPick.onDidAccept(async () => {
+			const selectedItem = quickPick.selectedItems[0];
+			if (selectedItem && (selectedItem as any).filter) {
+				const selectedFilter = (selectedItem as any).filter;
+				quickPick.dispose();
+				vscode.commands.executeCommand('workbench.action.findInFiles', {
+					filesToInclude: selectedFilter.include,
+					filesToExclude: selectedFilter.exclude,
+					triggerSearch: true,
+					isCaseSensitive: false,
+					matchWholeWord: false,
+					isRegex: false,
+					showIncludesExcludes: true
+				});
+			}
 		});
+
+		quickPick.onDidHide(() => quickPick.dispose());
+		quickPick.show();
 	});
 
 	context.subscriptions.push(selectAndSearchDisposable);
@@ -411,7 +604,7 @@ export function activate(context: vscode.ExtensionContext) {
 	// Command to delete a custom search filter
 	const deleteFilterDisposable = vscode.commands.registerCommand('custom-search-filters.deleteFilter', async () => {
 		// 1. Retrieve saved filters
-		let savedFilters: SearchFilter[] = context.globalState.get<SearchFilter[]>(FILTERS_STORAGE_KEY) || [];
+		let savedFilters: SearchFilter[] = loadAllFilters(context);
 
 		if (savedFilters.length === 0) {
 			vscode.window.showInformationMessage('No custom search filters to delete.');
@@ -420,7 +613,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 		// 2. Prepare Quick Pick items
 		const quickPickItems = savedFilters.map(filter => ({ 
-			label: filter.name, 
+			label: formatFilterLabel(filter), 
 			description: `Include: ${filter.include || '(none)'}, Exclude: ${filter.exclude || '(none)'}`, 
 			filter: filter // Store the actual filter object
 		}));
@@ -433,18 +626,7 @@ export function activate(context: vscode.ExtensionContext) {
 		if (!selectedItem) { return; } // User cancelled
 
 		// 4. Find and remove the selected filter
-		try {
-			const filterToDelete = selectedItem.filter;
-			const updatedFilters = savedFilters.filter(f => f.name !== filterToDelete.name);
-			
-			// 5. Update storage
-			await context.globalState.update(FILTERS_STORAGE_KEY, updatedFilters);
-			vscode.window.showInformationMessage(`Search filter '${filterToDelete.name}' deleted successfully!`);
-
-		} catch (error) {
-			console.error('Error deleting search filter:', error);
-			vscode.window.showErrorMessage('Failed to delete search filter. See console for details.');
-		}
+		await deleteFilter(context, selectedItem.filter);
 	});
 
 	context.subscriptions.push(deleteFilterDisposable); // Register the new command
@@ -452,7 +634,7 @@ export function activate(context: vscode.ExtensionContext) {
 	// Command to combine existing filters
 	const combineFiltersDisposable = vscode.commands.registerCommand('custom-search-filters.combineFilters', async () => {
 		// 1. Retrieve saved filters
-		let savedFilters: SearchFilter[] = context.globalState.get<SearchFilter[]>(FILTERS_STORAGE_KEY) || [];
+		let savedFilters: SearchFilter[] = loadAllFilters(context);
 
 		if (savedFilters.length < 2) {
 			vscode.window.showInformationMessage('You need at least two existing filters to combine.');
@@ -461,7 +643,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 		// 2. Prepare Quick Pick items for multi-selection
 		const quickPickItems = savedFilters.map(filter => ({ 
-			label: filter.name, 
+			label: formatFilterLabel(filter), 
 			description: `Include: ${filter.include || '(none)'}, Exclude: ${filter.exclude || '(none)'}`, 
 			filter: filter // Store the actual filter object
 		}));
@@ -543,7 +725,7 @@ export function activate(context: vscode.ExtensionContext) {
 	// --- NEW: Command to Edit an Existing Filter ---
 	const editFilterDisposable = vscode.commands.registerCommand('custom-search-filters.editFilter', async () => {
 		// 1. Retrieve saved filters
-		let savedFilters: SearchFilter[] = context.globalState.get<SearchFilter[]>(FILTERS_STORAGE_KEY) || [];
+		let savedFilters: SearchFilter[] = loadAllFilters(context);
 
 		if (savedFilters.length === 0) {
 			vscode.window.showInformationMessage('No custom search filters saved yet to edit.');
@@ -552,7 +734,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 		// 2. Prepare Quick Pick items for selection
 		const quickPickItems = savedFilters.map(filter => ({ 
-			label: filter.name, 
+			label: formatFilterLabel(filter), 
 			description: `Include: ${filter.include || '(none)'}, Exclude: ${filter.exclude || '(none)'}`, 
 			filter: filter // Store the actual filter object
 		}));
@@ -610,45 +792,55 @@ export function activate(context: vscode.ExtensionContext) {
 		console.log('[EditFilter Debug] Final exclude pattern:', finalExcludePattern); // <-- ADDED LOG
 
         // --- Create updated filter, check name conflicts, save (logic remains the same) ---
+        const filterScope = originalFilter.scope || 'global';
         const updatedFilter: SearchFilter = {
 			name: newFilterName.trim(), // Trim the validated name
 			include: finalIncludePattern,
-			exclude: finalExcludePattern
+			exclude: finalExcludePattern,
+			scope: filterScope // Preserve the original scope
 		};
-        console.log('[EditFilter Debug] Constructed updated filter:', updatedFilter); // <-- ADDED LOG
 
 		// 8. Handle potential name conflicts if the name was changed
         if (originalName !== updatedFilter.name) {
-            console.log('[EditFilter Debug] Name changed. Checking conflict for:', updatedFilter.name); // <-- ADDED LOG
-            const conflictingFilterExists = savedFilters.some(f => f.name === updatedFilter.name);
+            const conflictingFilterExists = savedFilters.some(f => f.name === updatedFilter.name && f.scope === filterScope);
             if (conflictingFilterExists) {
-                console.error('[EditFilter Debug] Name conflict detected.'); // <-- ADDED LOG
-                vscode.window.showErrorMessage(`A filter with the name '${updatedFilter.name}' already exists. Please choose a different name.`);
+                vscode.window.showErrorMessage(`A filter with the name '${updatedFilter.name}' already exists in ${filterScope === 'global' ? 'global' : 'project'} scope. Please choose a different name.`);
                 return; // Stop the edit process
             }
-        } else {
-             console.log('[EditFilter Debug] Name not changed, skipping conflict check.'); // <-- ADDED LOG
         }
 
-		// 9. Find the original filter in the array and update it
+		// 9. Save the updated filter to the appropriate location
 		try {
-            console.log('[EditFilter Debug] Attempting to find original filter with name:', originalName); // <-- ADDED LOG
-            const indexToUpdate = savedFilters.findIndex(f => f.name === originalName);
-            console.log('[EditFilter Debug] Found index:', indexToUpdate); // <-- ADDED LOG
-
-            if (indexToUpdate > -1) {
-                savedFilters[indexToUpdate] = updatedFilter; // Replace with the updated version
-                console.log('[EditFilter Debug] Attempting to update globalState...'); // <-- ADDED LOG
-                await context.globalState.update(FILTERS_STORAGE_KEY, savedFilters);
-                console.log('[EditFilter Debug] globalState update successful.'); // <-- ADDED LOG
-			    vscode.window.showInformationMessage(`Search filter '${updatedFilter.name}' updated successfully!`);
+            if (filterScope === 'workspace') {
+                // Update in project file
+                const projectFilters = loadProjectFilters();
+                const existingIndex = projectFilters.findIndex(f => f.name === originalName);
+                if (existingIndex > -1) {
+                    projectFilters[existingIndex] = updatedFilter;
+                } else {
+                    // If not found, add it (shouldn't happen, but handle gracefully)
+                    projectFilters.push(updatedFilter);
+                }
+                if (saveProjectFilters(projectFilters)) {
+                    vscode.window.showInformationMessage(`Search filter '${updatedFilter.name}' updated in project successfully!`);
+                } else {
+                    vscode.window.showErrorMessage('Failed to update filter in project. See console for details.');
+                }
             } else {
-                console.error('[EditFilter Debug] Original filter not found in savedFilters array.'); // <-- ADDED LOG
-                // Should theoretically not happen if selection worked
-                vscode.window.showErrorMessage(`Could not find the original filter '${originalName}' to update.`);
+                // Update in global state
+                let globalFilters: SearchFilter[] = context.globalState.get<SearchFilter[]>(FILTERS_STORAGE_KEY) || [];
+                const existingIndex = globalFilters.findIndex(f => f.name === originalName);
+                if (existingIndex > -1) {
+                    globalFilters[existingIndex] = updatedFilter;
+                } else {
+                    // If not found, add it (shouldn't happen, but handle gracefully)
+                    globalFilters.push(updatedFilter);
+                }
+                await context.globalState.update(FILTERS_STORAGE_KEY, globalFilters);
+                vscode.window.showInformationMessage(`Search filter '${updatedFilter.name}' updated globally successfully!`);
             }
 		} catch (error) {
-			console.error('[EditFilter Debug] Error during update/save:', error); // <-- ADDED LOG
+			console.error('Error updating search filter:', error);
 			vscode.window.showErrorMessage('Failed to update search filter. See console for details.');
 		}
 	});


### PR DESCRIPTION
<img width="1238" height="548" alt="image" src="https://github.com/user-attachments/assets/20eac37a-87f0-4396-9757-4996050fa12a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce global/workspace-scoped filters with settings/project storage, migration, enable/disable support, scope-aware UI/operations, and remove the combine-filters command.
> 
> - **Core/Storage**:
>   - Add filter scopes (`global` and `workspace`) with persistence in VS Code settings (`custom-search-filters.globalFilters`, `custom-search-filters.globalFiltersEnabled`) and project file (`.vscode/custom-search-filters.json`).
>   - Implement migration from `globalState` to settings and unify loading across both sources.
>   - Preserve scope and enabled state on save/edit; delete respects scope and cleans up settings.
> - **Behavior/UI**:
>   - Filter selection excludes disabled global filters; labels show scope icons; prompt for scope when creating filters.
>   - Quick Pick for selection adds inline delete button; context menu add/update flows now load/save with scope awareness and avoid duplicates.
> - **Config/Docs**:
>   - Add configuration schema in `package.json`; remove `combineFilters` command and contributions; bump version to `0.1.4`.
>   - Update `README.md` with "Filter Scope and Storage" section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d78213c3b398fd4fdf9799c5df45d18403d63b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->