### PR TITLE
feat: add search panel icon and fix icon rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
       },
       {
         "command": "custom-search-filters.selectAndSearch",
-        "title": "Custom Search: Select Filter and Search"
+        "title": "Custom Search: Select Filter and Search",
+        "icon": "$(filter)"
       },
       {
         "command": "custom-search-filters.deleteFilter",
@@ -101,6 +102,14 @@
       }
     },
     "menus": {
+      "view/title": [
+        {
+          "command": "custom-search-filters.selectAndSearch",
+          "when": "view == workbench.view.search",
+          "group": "navigation",
+          "icon": "$(filter)"
+        }
+      ],
       "editor/title": [
         {
           "command": "custom-search-filters.selectAndSearch",


### PR DESCRIPTION
### Description
Currently, the _'Select Filter and Search'_ command is only accessible via the Command Palette or the Editor tool bar. 

### Changes
- **Search Panel Icon:** This PR adds the filter icon directly to the tool bar of the Search Panel.
- **Icon (bug) Fix:** Registered the icon in the `commands` section to fix rendering of the icon (for both Editor tool bar and Search tool bar).